### PR TITLE
Better header removement

### DIFF
--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -59,7 +59,7 @@ class HttpServer extends EventEmitter
             if (!$headerCompleted) {
                 $headerDecoder->on('data', function ($header) use (&$request, &$data, &$headerCompleted) {
                     $request = RingCentral\Psr7\parse_request($header);
-                    $data = str_replace($header, '', $data);
+                    $data = substr($data, strlen($header));
                     $headerCompleted = true;
                 });
                 $headerStream->emit('data', array($data));


### PR DESCRIPTION
Remove header by substr. strreplace can lead to errors, if the header is also written in the body