### PR TITLE
Allow `React\Promise\Promise` as return type for the callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,18 @@ $httpServer = new HttpServer($socket, $callback);
 The return type of the callback function **must** be a [response object](https://packagist.org/packages/ringcentral/psr7) or
 a [promise](https://github.com/reactphp/promise).
 
-If you have blocking operations in the callback function, you should consider using promises. Not using them can slow down the
-server. Checkout the `examples` folder how to use promises in the callback function.
+For heavy calculations you should consider using promises. Not using them can slow down the server.
+
+```php
+$callback = function (Request $request) {
+    return new Promise(function ($resolve, $reject) use ($request) {
+        // Some heavy calculations
+        $resolve(new Response());
+    });
+};
+```
+Checkout the `examples` folder how to use promises in the callback function.
+
 The promise **must** return a response object anything else will lead to a 'HTTP 500 Internal Server Error' response for the client.
 
 Other types aren't allowed and will lead to a 'HTTP 500 Internal Server Error' response for the client.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ a [promise](https://github.com/reactphp/promise).
 
 If you have blocking operations in the callback function, you should consider using promises. Not using them can slow down the
 server. Checkout the `examples` folder how to use promises in the callback function.
+The promise **must** return a response object anything else will lead to a 'HTTP 500 Internal Server Error' response for the client.
 
-Other types aren't allowed and will lead to an 'HTTP 500 Internal Server Error' for the client.
+Other types aren't allowed and will lead to a 'HTTP 500 Internal Server Error' response for the client.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,12 @@ $httpServer = new HttpServer($socket, $callback);
 
 #### Return type of the callback function
 
-The return type of the callback function **must** be a response object.
+The return type of the callback function **must** be a [response object](https://packagist.org/packages/ringcentral/psr7) or
+a [promise](https://github.com/reactphp/promise).
+
+If you have blocking operations in the callback function, you should consider using promises. Not using them can slow down the
+server. Checkout the `examples` folder how to use promises in the callback function.
+
 Other types aren't allowed and will lead to an 'HTTP 500 Internal Server Error' for the client.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ For heavy calculations you should consider using promises. Not using them can sl
 ```php
 $callback = function (Request $request) {
     return new Promise(function ($resolve, $reject) use ($request) {
-        // Some heavy calculations
-        $resolve(new Response());
+        $response = heavyCalculationFunction();
+        $resolve($response);
     });
 };
 ```

--- a/examples/returningPromise.php
+++ b/examples/returningPromise.php
@@ -9,12 +9,16 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
-$callback = function() use ($loop) {
-    return new Promise(function($resolve, $reject) use ($loop) {
-        // Some heavy caluclations
-        $loop->addTimer(2, function () use ($resolve){
-            $resolve(new Response());
-        });
+$pseudoHeavyCalculation = function ($resolve) use ($loop){
+    // Needs 2 seconds to answer a reequest caused by "calculations"
+    $loop->addTimer(2, function () use ($resolve){
+        $resolve(new Response());
+    });
+};
+
+$callback = function() use ($loop, $pseudoHeavyCalculation) {
+    return new Promise(function($resolve, $reject) use ($loop, $pseudoHeavyCalculation) {
+        $pseudoHeavyCalculation($resolve);
     });
 };
 

--- a/examples/returningPromise.php
+++ b/examples/returningPromise.php
@@ -1,0 +1,25 @@
+<?php
+
+use Legionth\React\Http\HttpServer;
+use React\Socket\Server as Socket;
+use React\Promise\Promise;
+use RingCentral\Psr7\Response;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$callback = function() {
+    return new Promise(function($resolve, $reject) {
+        // Some heavy caluclations
+        sleep(2);
+        $resolve(new Response());
+    });
+};
+
+$loop = React\EventLoop\Factory::create();
+
+$socket = new Socket($loop);
+$socket->listen(10000, 'localhost');
+
+$server = new HttpServer($socket, $callback);
+
+$loop->run();

--- a/examples/returningPromise.php
+++ b/examples/returningPromise.php
@@ -7,15 +7,16 @@ use RingCentral\Psr7\Response;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$callback = function() {
-    return new Promise(function($resolve, $reject) {
+$loop = React\EventLoop\Factory::create();
+
+$callback = function() use ($loop) {
+    return new Promise(function($resolve, $reject) use ($loop) {
         // Some heavy caluclations
-        sleep(2);
-        $resolve(new Response());
+        $loop->addTimer(2, function () use ($resolve){
+            $resolve(new Response());
+        });
     });
 };
-
-$loop = React\EventLoop\Factory::create();
 
 $socket = new Socket($loop);
 $socket->listen(10000, 'localhost');

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -148,8 +148,14 @@ class HttpServer extends EventEmitter
      */
     private function handlePromise(Connection $connection, Promise $promise)
     {
-        $promise->then(function ($response) use ($connection){
-            $connection->write(RingCentral\Psr7\str($response));
+        $promise->then(function ($response) use ($connection, $promise){
+            $responseString = RingCentral\Psr7\str(new Response(500));
+
+            if ($response instanceof Response) {
+                $responseString = RingCentral\Psr7\str($response);
+            }
+
+            $connection->write($responseString);
             $connection->end();
         },
         function () use ($connection) {

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -11,6 +11,7 @@ use RingCentral\Psr7\Request;
 use React\Socket\ConnectionInterface;
 use RingCentral;
 use React\Stream\ReadableStream;
+use React\Promise\Promise;
 
 class HttpServer extends EventEmitter
 {
@@ -120,6 +121,12 @@ class HttpServer extends EventEmitter
 
         try {
             $response = $callback($request);
+
+            if ($response instanceof Promise) {
+                $this->handlePromise($connection, $response);
+                return;
+            }
+
             if (!$response instanceof Response) {
                 throw new InvalidResponseTypeException('The returned type of callback function is invalid');
             }
@@ -131,6 +138,24 @@ class HttpServer extends EventEmitter
 
         $connection->write(RingCentral\Psr7\str($response));
         $connection->end();
+    }
+
+    /**
+     * Handles an promise
+     *
+     * @param Connection $connection - connection between server and client
+     * @param Promise $promise - Promise returned by the callback function of the server
+     */
+    private function handlePromise(Connection $connection, Promise $promise)
+    {
+        $promise->then(function ($response) use ($connection){
+            $connection->write(RingCentral\Psr7\str($response));
+            $connection->end();
+        },
+        function () use ($connection) {
+            $connection->write(RingCentral\Psr7\str(new Response(500)));
+            $connection->end();
+        });
     }
 
     /**

--- a/tests/HttpServerTest.php
+++ b/tests/HttpServerTest.php
@@ -91,7 +91,7 @@ class HttpServerTest extends TestCase
         $this->connection->emit('data', array($request));
     }
 
-    public function testCallbackFunctionReturnsPromise()
+    public function testCallbackFunctionReturnsPromiseAndServerResponsesWithOkMessage()
     {
         $callback = function () {
             return new Promise(function ($resolve, $reject) {
@@ -109,7 +109,7 @@ class HttpServerTest extends TestCase
         $this->connection->emit('data', array($request));
     }
 
-    public function testPromiseReturnsInvalidValue()
+    public function testPromiseReturnsInvalidValueAndServerResponsesWhithInternalErrorMessage()
     {
         $callback = function () {
             return new Promise(function ($resolve, $reject) {
@@ -127,7 +127,7 @@ class HttpServerTest extends TestCase
         $this->connection->emit('data', array($request));
     }
 
-    public function testPromiseThrowsException()
+    public function testPromiseThrowsExceptionAndServerResponsesWithInternalServer()
     {
         $callback = function () {
             return new Promise(function ($resolve, $reject) {


### PR DESCRIPTION
Promises are now allowed as return type in the callback function.