### PR TITLE
Add HTTP middleware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,15 @@ Other types aren't allowed and will lead to a 'HTTP 500 Internal Server Error' r
 
 #### Creating your own middleware
 
-You can create your own middleware, which lies between the server and the callback function. Use this middleware to manipulate the requests or
-responses of the server. You can add as many middleware as you want you just need to follow the following design
+You can create your own middleware. These middleware lies between the `HttpServer` and the user callback function. The `HttpServer` would
+call the callback function, if the response object is created. With an added middleware the `HttpServer` will call this middleware first.
+The next chain link would be another middleware or the callback function at the end. Every middleware has to return an response object.
+Otherwise the `HttpServer` will return a "500 Internal Server Error" message.
+The middleware can not only manipulate the request objects, but also the response objects returned by the other added middleware or the callback function.
+
+This is similiar to the conecept of [the fig standards](https://github.com/php-fig/fig-standards/blob/master/proposed/http-middleware/middleware-meta.md).
+
+Add as many middlewares as you want you just need to follow the following design
 
 ```php
 $callback = function (RequestInterface $request) {
@@ -140,7 +147,7 @@ $server = new HttpServer($socket, $callback);
 $server->addMiddleware($middleware);
 ```
 
-Make sure you add the `return $next($request)` in your middleware code. Otherwise the client will receive a `500 Internal Server Error` message.
+Make sure you add the `return $next($request)` in your middleware code. Otherwise the response of the last called middleware will be returned.
 The `return $next($request)` will call the next middleware or the user callback function, if it's the last part of this middleware chain.
 
 The added middleware will be executed the order you added them.
@@ -149,17 +156,36 @@ The added middleware will be executed the order you added them.
 ...
 
 $timeBlockingMiddleware = function (RequestInterface $request, callable $next) {
+    // Will call the next middleware from 00:00 till 16:00
+    // otherwise an 403 Forbidden response will be sent to the client
+    if (((int)date('Hi') < 1600 && (int)date('Hi') > 0) {
+        return $next($request);
+    }
+    return new Response(403);
+};
 
+$addHeaderToRequest = function (RequestInterface $request, callable $next) {
+    $request = $request->withAddedHeader('Date', date('Y-m-d'));
+    return $next($request);
+};
+
+$addHeaderToResponse = function (RequestInterface $request, callable $next) {
+    $response = $next($request);
+    $response = $response->withAddedHeader('Age', '12');
+    return $response;
 };
 
 $server = new HttpServer($socket, $callback);
-$server->addMiddleware($timeBlockingMiddleWare);
-$server->addMiddleware($addedHeaderMiddleware);
+$server->addMiddleware($timeBlockingMiddleware);
+$server->addMiddleware($addHeaderToRequest);
+$server->addMiddleware($addHeaderToResponse);
 ```
-In this example `$timeBlockingMiddleWare` will be called first and the `$addedHeaderMiddleware` as second.
+In this example `$timeBlockingMiddleWare` will be called first, the `$addHeaderToRequest` as second and `$addHeaderToResponse` as third .
 The last part of the chain is the `callback` function.
 
-Checkout the `examples/middleware` how to add mutliple middleware.
+This little example should show how you can use the middlwares e.g. to check or manipulate the requests/response objects.
+
+Checkout the `examples/middleware` how to add multiple middlewares.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -122,14 +122,14 @@ Other types aren't allowed and will lead to a 'HTTP 500 Internal Server Error' r
 #### Creating your own middleware
 
 You can create your own middleware, which lies between the server and the callback function. Use this middleware to manipulate the requests or
-responses of the server. You can add as many middlewar as you want you just need to follow the following design
+responses of the server. You can add as many middleware as you want you just need to follow the following design
 
 ```php
 $callback = function (RequestInterface $request) {
     return new Response();
 }
 
-$middleware = function (RequestInterface $request, callable callables) {
+$middleware = function (RequestInterface $request, array $callables) {
     // check or maninpulate the request object
     ...
     // fetch the next part of the callable chain und remove it from the array

--- a/README.md
+++ b/README.md
@@ -129,31 +129,37 @@ $callback = function (RequestInterface $request) {
     return new Response();
 }
 
-$middleware = function (RequestInterface $request, array $callables) {
+$middleware = function (RequestInterface $request, callable $next) {
     // check or maninpulate the request object
     ...
-    // fetch the next part of the callable chain und remove it from the array
-    $next = array_shift($callables);
-    // execute the next callable and return its value
-    return $next($request, $callables);
+    // call of next middleware chain link
+    return $next($request);
 }
 
 $server = new HttpServer($socket, $callback);
 $server->addMiddleware($middleware);
 ```
 
-Make sure you remove the next entry from the callables chain. Best way to use it is: `$next = array_shift($callables)`, like in the example above.
-Don't forget the `return` of your `$next(...)` call, otherwise the `HttpServer` won't get any response object to work with.
+Make sure you add the `return $next($request)` in your middleware code. Otherwise the client will receive a `500 Internal Server Error` message.
+The `return $next($request)` will call the next middleware or the user callback function, if it's the last part of this middleware chain.
 
-The added middlware will be executed the order you added them.
+The added middleware will be executed the order you added them.
 
 ```php
+...
+
+$timeBlockingMiddleware = function (RequestInterface $request, callable $next) {
+
+};
+
 $server = new HttpServer($socket, $callback);
 $server->addMiddleware($timeBlockingMiddleWare);
-$server->addMiddleware($geoBlockingMiddleWare);
+$server->addMiddleware($addedHeaderMiddleware);
 ```
-In this example `$timeBlockingMiddleWare` will be called first and the `$geoBlockingMiddleWare` as second.
+In this example `$timeBlockingMiddleWare` will be called first and the `$addedHeaderMiddleware` as second.
 The last part of the chain is the `callback` function.
+
+Checkout the `examples/middleware` how to add mutliple middleware.
 
 ## Install
 

--- a/examples/middleware.php
+++ b/examples/middleware.php
@@ -1,0 +1,59 @@
+<?php
+
+use Legionth\React\Http\HttpServer;
+use React\Socket\Server as Socket;
+use RingCentral\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$callback = function($request) {
+    $body = '
+<html>
+<body>
+    <h1> Welcome to our midnight shop! </h1>
+</body>
+</html>';
+
+    return new Response(
+        200,
+        array(
+            'Content-Length' => strlen($body),
+            'Content-Type' => 'text/html'
+        ),
+        $body);
+};
+
+$loop = React\EventLoop\Factory::create();
+
+$socket = new Socket($loop);
+$socket->listen(10000, 'localhost');
+
+$middlewareTimeBlocking = function (RequestInterface $request, array $callables) {
+    // This middleware only allows the call of callback function
+    // only between 00:00 am and 01:00 am
+    if ((int)date('Hi') < 100 && (int)date('Hi') > 0) {
+        $next = array_shift($callables);
+        return $next($request, $callables);
+    }
+    
+    $body = '
+<html>
+<body>
+    <h1> Sorry the midnight shop is only open from midnight to 1 am! </h1>
+</body>
+</html>';
+    
+    return new Response(
+        200,
+        array(
+            'Content-Length' => strlen($body),
+            'Content-Type' => 'text/html'
+        ),
+        $body);
+};
+
+$server = new HttpServer($socket, $callback);
+$server->addMiddleware($middlewareTimeBlocking);
+
+$loop->run();

--- a/examples/middleware.php
+++ b/examples/middleware.php
@@ -29,21 +29,20 @@ $loop = React\EventLoop\Factory::create();
 $socket = new Socket($loop);
 $socket->listen(10000, 'localhost');
 
-$middlewareTimeBlocking = function (RequestInterface $request, array $callables) {
+$middlewareTimeBlocking = function (RequestInterface $request, callable $next) {
     // This middleware only allows the call of callback function
     // only between 00:00 am and 01:00 am
     if ((int)date('Hi') < 100 && (int)date('Hi') > 0) {
-        $next = array_shift($callables);
-        return $next($request, $callables);
+        return $next($request);
     }
-    
+
     $body = '
 <html>
 <body>
     <h1> Sorry the midnight shop is only open from midnight to 1 am! </h1>
 </body>
 </html>';
-    
+
     return new Response(
         200,
         array(
@@ -53,7 +52,20 @@ $middlewareTimeBlocking = function (RequestInterface $request, array $callables)
         $body);
 };
 
+$middlewareAddLanguageHeader = function (RequestInterface $request, callable $next) {
+    $request = $request->withAddedHeader('Language', 'german');
+    return $next($request);
+};
+
+$middlewareAddDateHeaderToResponse = function (RequestInterface $request, callable $next) {
+    $response = $next($request);
+    $response = $response->withAddedHeader('Date', date('Y-m-d'));
+    return $response;
+};
+
 $server = new HttpServer($socket, $callback);
 $server->addMiddleware($middlewareTimeBlocking);
+$server->addMiddleware($middlewareAddLanguageHeader);
+$server->addMiddleware($middlewareAddDateHeaderToResponse);
 
 $loop->run();

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -19,8 +19,7 @@ class HttpServer extends EventEmitter
 
     private $socket;
     private $callback;
-    private $middleware;
-    private $lastMiddleware;
+    private $middlewares;
 
     /**
      *
@@ -39,11 +38,13 @@ class HttpServer extends EventEmitter
             $this,
             'handleConnection'
         ));
+
+        $this->middlewares = array();
     }
 
-    public function addMiddleware(Middleware $middlware)
+    public function addMiddleware(callable $middleware)
     {
-        $this->middleware = $middlware;
+        $this->middlewares[] = $middleware;
     }
 
     /**
@@ -128,8 +129,8 @@ class HttpServer extends EventEmitter
         $callback = $this->callback;
 
         try {
-            $response = $this->middleware->process($request, $callback);
-//             $response = $callback($request);
+            $this->middlewares[] = $this->callback;
+            $response = $this->middlewares[0]($request, $this->middlewares);
 
             $promise = $response;
             if (!$promise instanceof Promise) {

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -42,8 +42,12 @@ class HttpServer extends EventEmitter
         $this->middlewares = array();
     }
 
-    public function addMiddleware(callable $middleware)
+    public function addMiddleware($middleware)
     {
+        if (!is_callable($middleware)) {
+            throw new \InvalidArgumentException('The given parameter is not callable');
+        }
+
         $this->middlewares[] = $middleware;
     }
 

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -134,7 +134,8 @@ class HttpServer extends EventEmitter
 
         try {
             $this->middlewares[] = $this->callback;
-            $response = $this->middlewares[0]($request, $this->middlewares);
+            $firstCallbackFunction = array_shift($this->middlewares);
+            $response = $firstCallbackFunction($request, $this->middlewares);
 
             $promise = $response;
             if (!$promise instanceof Promise) {

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -12,12 +12,15 @@ use React\Socket\ConnectionInterface;
 use RingCentral;
 use React\Stream\ReadableStream;
 use React\Promise\Promise;
+use Legionth\React\Http\Middleware;
 
 class HttpServer extends EventEmitter
 {
 
     private $socket;
     private $callback;
+    private $middleware;
+    private $lastMiddleware;
 
     /**
      *
@@ -36,6 +39,11 @@ class HttpServer extends EventEmitter
             $this,
             'handleConnection'
         ));
+    }
+
+    public function addMiddleware(Middleware $middlware)
+    {
+        $this->middleware = $middlware;
     }
 
     /**
@@ -120,7 +128,8 @@ class HttpServer extends EventEmitter
         $callback = $this->callback;
 
         try {
-            $response = $callback($request);
+            $response = $this->middleware->process($request, $callback);
+//             $response = $callback($request);
 
             $promise = $response;
             if (!$promise instanceof Promise) {

--- a/tests/HttpServerTest.php
+++ b/tests/HttpServerTest.php
@@ -158,7 +158,8 @@ class HttpServerTest extends TestCase
     public function testAddOneMiddleware()
     {
         $callback = function (RequestInterface $request) {
-            if (empty($request->getHeader('From'))) {
+            $headerArray = $request->getHeader('From');
+            if (empty($headerArray)) {
                 throw new Exception();
             }
 
@@ -187,8 +188,9 @@ class HttpServerTest extends TestCase
     public function testAddTwoMiddlwares()
     {
         $callback = function (RequestInterface $request) {
+            $headerArray = $request->getHeader('From');
             // Second middlware should remove the header added by the first middleware
-            if (empty($request->getHeader('From'))) {
+            if (empty($headerArray)) {
                 return new Response();
             }
             throw new Exception();

--- a/tests/HttpServerTest.php
+++ b/tests/HttpServerTest.php
@@ -166,11 +166,14 @@ class HttpServerTest extends TestCase
             return new Response();
         };
 
-        $middleware = function (RequestInterface $request, array $callables) {
+        $middleware = function (RequestInterface $request, $next) {
+            if (!is_callable($next)) {
+                throw new Exception();
+            }
+
             $request = $request->withAddedHeader('From', 'user@example.com');
 
-            $next = array_shift($callables);
-            return $next($request, $callables);
+            return $next($request);
         };
 
         $request = "GET / HTTP/1.1\r\nHost: me.you\r\n\r\n";
@@ -196,18 +199,24 @@ class HttpServerTest extends TestCase
             throw new Exception();
         };
 
-        $middleware = function (RequestInterface $request, array $callables) {
+        $middleware = function (RequestInterface $request, $next) {
+            if (!is_callable($next)) {
+                throw new Exception();
+            }
+
             $request = $request->withAddedHeader('From', 'user@example.com');
 
-            $next = array_shift($callables);
-            return $next($request, $callables);
+            return $next($request);
         };
 
-        $middlewareTwo = function (RequestInterface $request, array $callables) {
+        $middlewareTwo = function (RequestInterface $request, $next) {
+            if (!is_callable($next)) {
+                throw new Exception();
+            }
+
             $request = $request->withoutHeader('From');
 
-            $next = array_shift($callables);
-            return $next($request, $callables);
+            return $next($request);
         };
 
         $request = "GET / HTTP/1.1\r\nHost: me.you\r\n\r\n";
@@ -229,13 +238,16 @@ class HttpServerTest extends TestCase
             return new Response();
         };
 
-        $middleware = function (RequestInterface $request, array $callables) {
+        $middleware = function (RequestInterface $request, $next) {
+            if (!is_callable($next)) {
+                throw new Exception();
+            }
+
             $host = $request->getHeader('Host');
             if ($host[0] == "me.you") {
                 return new Response(400);
             }
-            $next = array_shift($callables);
-            return $next($request, $callables);
+            return $next($request);
         };
 
         $request = "GET / HTTP/1.1\r\nHost: me.you\r\n\r\n";


### PR DESCRIPTION
Add middleware support for `HttpServer`. Middleware can be used to manipulate requests/responses between the user callback function and the `HttpServer`