### PR TITLE
Add HTTP body streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ HTTP server written in PHP on top of ReactPHP.
  * [Return type of the callback function](#return-type-of-the-callback-function)
  * [Middleware](#middleware)
   * [Creating your own middleware](#creating-your-own-middleware)
- * [Streaming body data](#streaming-body-data)
+ * [Streaming responses](#streaming-responses)
 * [License](#license)
 
 ## Usage
@@ -188,7 +188,7 @@ This little example should show how you can use the middlwares e.g. to check or 
 
 Checkout the `examples/middleware` how to add multiple middlewares.
 
-### Streaming body data
+### Streaming responses
 
 Data that would take a while to be completed caused by computation, can be streamed directly to the client without buffering the whole data.
 Streaming makes it possible to send big amount of data in small chunks to the client.
@@ -212,7 +212,7 @@ $callback = function (RequestInterface $request) {
 ```
 
 The `HttpServer` will use the emitted data from the `ReadableStream` to send this data directly to the client.
-If you use the `HttpBodyStream` the whole communication to the client will be HTTP chunk encoded, other values set for `Transfer-Encoding` will be ignored.
+If you use the `HttpBodyStream` the whole transfer will be [chunked encoded](https://en.wikipedia.org/wiki/Chunked_transfer_encoding), other values set for `Transfer-Encoding` will be ignored.
 
 Check out the `examples` folder how your computation could look like.
 

--- a/README.md
+++ b/README.md
@@ -212,12 +212,9 @@ $callback = function (RequestInterface $request) {
 ```
 
 The `HttpServer` will use the emitted data from the `ReadableStream` to send this data directly to the client.
+If you use the `HttpBodyStream` the whole communication to the client will be HTTP chunk encoded, other values set for `Transfer-Encoding` will be ignored.
 
-You can add an the optional encoder as second parameter of the constructor of the `HttpBodyStream`. If none is set the default will the be`ChunkedEncoderStream` an 
-encoder which will send HTTP encoded chunks to the client.
-The `HttpServer` will automaticly add a 'Transfer-Encoding: chunked' line to your header, if you use the `HttpBodyStream` with the default `ChunkedEncoderStream`.
-
-The advantage of streaming data is that big amount of data doesn't need to be saved temporarily, because it will be send directly to the client.
+Big amount of data can easily be handled and doesn't need to be saved temporarily, because it will be send directly to the client.
 
 Check out the `examples` folder how your computation could look like.
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ You can add an the optional encoder as second parameter of the constructor of th
 encoder which will send HTTP encoded chunks to the client.
 The `HttpServer` will automaticly add a 'Transfer-Encoding: chunked' line to your header, if you use the `HttpBodyStream` with the default `ChunkedEncoderStream`.
 
+The advantage of streaming data is that big amount of data doesn't need to be saved temporarily, because it will be send directly to the client.
+
 Check out the `examples` folder how your computation could look like.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ HTTP server written in PHP on top of ReactPHP.
  * [Return type of the callback function](#return-type-of-the-callback-function)
  * [Middleware](#middleware)
   * [Creating your own middleware](#creating-your-own-middleware)
+ * [Streaming body data](#streaming-body-data)
 * [License](#license)
 
 ## Usage
@@ -186,6 +187,36 @@ The last part of the chain is the `callback` function.
 This little example should show how you can use the middlwares e.g. to check or manipulate the requests/response objects.
 
 Checkout the `examples/middleware` how to add multiple middlewares.
+
+### Streaming body data
+
+If you have operations that need time to be computed(of course non-blocking ;-)), you can stream the intermediary results directly to the client,
+without buffering on your side.
+
+Use an instance of the `HttpBodyStream` and use this instance as the body for `Response` object you want to return.
+
+```php
+$callback = function (RequestInterface $request) {
+    $input = new ReadableStream();
+    $body = new HttpBodyStream($input);
+    
+    // your computation
+    // emit via `$input`
+    
+    return new Response(
+        200,
+        array(
+            'Transfer-Encoding' => 'chunked',
+            'Connection' => 'keep-alive'
+        ),
+        $body
+    );
+}
+```
+
+The `HttpServer` will use the emitted data from the `ReadableStream` to send this data directly to the client.
+
+Check out the `examples` folder how your computation could look like.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ Checkout the `examples/middleware` how to add multiple middlewares.
 
 ### Streaming body data
 
-If you have operations that need time to be computed(of course non-blocking ;-)), you can stream the intermediary results directly to the client,
-without buffering on your side.
+Data that would take a while to be completed caused by computation, can be streamed directly to the client without buffering the whole data.
+Streaming makes it possible to send big amount of data in small chunks to the client.
 
 Use an instance of the `HttpBodyStream` and use this instance as the body for `Response` object you want to return.
 
@@ -213,8 +213,6 @@ $callback = function (RequestInterface $request) {
 
 The `HttpServer` will use the emitted data from the `ReadableStream` to send this data directly to the client.
 If you use the `HttpBodyStream` the whole communication to the client will be HTTP chunk encoded, other values set for `Transfer-Encoding` will be ignored.
-
-Big amount of data can easily be handled and doesn't need to be saved temporarily, because it will be send directly to the client.
 
 Check out the `examples` folder how your computation could look like.
 

--- a/README.md
+++ b/README.md
@@ -205,16 +205,17 @@ $callback = function (RequestInterface $request) {
     
     return new Response(
         200,
-        array(
-            'Transfer-Encoding' => 'chunked',
-            'Connection' => 'keep-alive'
-        ),
+        array(),
         $body
     );
 }
 ```
 
 The `HttpServer` will use the emitted data from the `ReadableStream` to send this data directly to the client.
+
+You can add an the optional encoder as second parameter of the constructor of the `HttpBodyStream`. If none is set the default will the be`ChunkedEncoderStream` an 
+encoder which will send HTTP encoded chunks to the client.
+The `HttpServer` will automaticly add a 'Transfer-Encoding: chunked' line to your header, if you use the `HttpBodyStream` with the default `ChunkedEncoderStream`.
 
 Check out the `examples` folder how your computation could look like.
 

--- a/examples/streamServer.php
+++ b/examples/streamServer.php
@@ -1,0 +1,44 @@
+<?php
+
+use Legionth\React\Http\HttpServer;
+use Legionth\React\Http\HttpBodyStream;
+use React\Socket\Server as Socket;
+use RingCentral\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use React\Stream\ReadableStream;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+
+$loop = React\EventLoop\Factory::create();
+
+$callback = function(RequestInterface $request) use ($loop){
+    $input = new ReadableStream();
+
+    $periodicTimer = $loop->addPeriodicTimer(0.5, function () use ($input) {
+        $input->emit('data', array("6\r\nworld\n\r\n"));
+    });
+
+    $loop->addTimer(3, function () use ($input, $periodicTimer) {
+        $periodicTimer->cancel();
+        $input->emit('data', array("3\r\nend\r\n0\r\n\r\n"));
+        $input->emit('end');
+    });
+
+    $body = new HttpBodyStream($input);
+
+    return new Response(
+        200,
+        array(
+            'Transfer-Encoding' => 'chunked',
+            'Connection' => 'keep-alive'
+        ),
+        $body);
+};
+
+$socket = new Socket($loop);
+$socket->listen(10000, 'localhost');
+
+$server = new HttpServer($socket, $callback);
+
+$loop->run();

--- a/examples/streamServer.php
+++ b/examples/streamServer.php
@@ -6,7 +6,6 @@ use React\Socket\Server as Socket;
 use RingCentral\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 use React\Stream\ReadableStream;
-use Legionth\React\Http\ChunkedEncoderStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 

--- a/examples/streamServer.php
+++ b/examples/streamServer.php
@@ -10,7 +10,6 @@ use Legionth\React\Http\ChunkedEncoderStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-
 $loop = React\EventLoop\Factory::create();
 
 $callback = function(RequestInterface $request) use ($loop){
@@ -33,7 +32,8 @@ $callback = function(RequestInterface $request) use ($loop){
         array(
             'Transfer-Encoding' => 'chunked'
         ),
-        $body);
+        $body
+    );
 };
 
 $socket = new Socket($loop);

--- a/examples/streamServer.php
+++ b/examples/streamServer.php
@@ -14,7 +14,6 @@ $loop = React\EventLoop\Factory::create();
 
 $callback = function(RequestInterface $request) use ($loop){
     $stream = new ReadableStream();
-    $input = new ChunkedEncoderStream($stream);
 
     $periodicTimer = $loop->addPeriodicTimer(0.5, function () use ($stream) {
         $stream->emit('data', array("world\n"));
@@ -25,13 +24,11 @@ $callback = function(RequestInterface $request) use ($loop){
         $stream->emit('end', array('end'));
     });
 
-    $body = new HttpBodyStream($input);
+    $body = new HttpBodyStream($stream);
 
     return new Response(
         200,
-        array(
-            'Transfer-Encoding' => 'chunked'
-        ),
+        array(),
         $body
     );
 };

--- a/src/ChunkedEncoderStream.php
+++ b/src/ChunkedEncoderStream.php
@@ -22,18 +22,27 @@ class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterfa
         $this->input->on('close', array($this, 'close'));
     }
 
+    /**
+     * @internal
+     */
     public function handleData($data)
     {
         $completeChunk = $this->createChunk($data);
         $this->emit('data', array($completeChunk));
     }
 
+    /**
+     * @internal
+     */
     public function handleError(\Exception $e)
     {
         $this->emit('error', array($e));
         $this->close();
     }
 
+    /**
+     * @internal
+     */
     public function handleEnd($data = null)
     {
         if ($data != null) {
@@ -49,6 +58,11 @@ class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterfa
         }
     }
 
+    /**
+     * @param string $data - string to be transformed in an valid
+     *                       HTTP encoded chunk string
+     * @return string
+     */
     private function createChunk($data)
     {
         $byteSize = strlen($data);

--- a/src/ChunkedEncoderStream.php
+++ b/src/ChunkedEncoderStream.php
@@ -50,13 +50,8 @@ class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterfa
      * @param string $data - data that should be written on the stream,
      *                       before it closes
      */
-    public function handleEnd($data = null)
+    public function handleEnd()
     {
-        if ($data != null) {
-            $completeChunk = $this->createChunk($data);
-            $this->emit('data', array($completeChunk));
-        }
-
         $this->emit('data', array("0\r\n\r\n"));
 
         if (!$this->closed) {
@@ -72,14 +67,10 @@ class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterfa
      */
     private function createChunk($data)
     {
-        if (is_string($data)) {
-            $byteSize = strlen($data);
-            $chunkBeginning = $byteSize . "\r\n";
+        $byteSize = strlen($data);
+        $chunkBeginning = $byteSize . "\r\n";
 
-            return $chunkBeginning . $data . "\r\n";
-        }
-
-        return '';
+        return $chunkBeginning . $data . "\r\n";
     }
 
     public function isReadable()
@@ -116,6 +107,7 @@ class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterfa
 
         $this->emit('end', array());
         $this->emit('close', array());
+
         $this->removeAllListeners();
     }
 }

--- a/src/ChunkedEncoderStream.php
+++ b/src/ChunkedEncoderStream.php
@@ -7,7 +7,7 @@ use React\Stream\WritableStreamInterface;
 use React\Stream\Util;
 
 /**
- * Stream incoming strings as a HTTP chunked encoded string
+ * Wraps any readable stream which will emit the data as HTTP chunks
  */
 class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterface
 {

--- a/src/ChunkedEncoderStream.php
+++ b/src/ChunkedEncoderStream.php
@@ -1,0 +1,127 @@
+<?php
+namespace Legionth\React\Http;
+
+use Evenement\EventEmitter;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+use React\Stream\Util;
+
+class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterface
+{
+    private $input;
+    private $closed;
+    private $closing = false;
+
+    public function __construct(ReadableStreamInterface $input)
+    {
+        $this->input = $input;
+
+        $this->input->on('data', array($this, 'handleData'));
+        $this->input->on('end', array($this, 'handleEnd'));
+        $this->input->on('error', array($this, 'handleError'));
+        $this->input->on('close', array($this, 'close'));
+    }
+
+    public function handleData($data)
+    {
+        $completeChunk = $this->createChunk($data);
+        $this->emit('data', array($completeChunk));
+    }
+
+    public function handleError(\Exception $e)
+    {
+        $this->emit('error', array($e));
+        $this->close();
+    }
+
+    public function handleEnd($data = null)
+    {
+        if ($data != null) {
+            $completeChunk = $this->createChunk($data);
+            $this->emit('data', array($completeChunk));
+        }
+
+        $this->emit('data', array("0\r\n\r\n"));
+
+        if (!$this->closed) {
+            $this->emit('end');
+            $this->close();
+        }
+    }
+
+    private function createChunk($data)
+    {
+        $byteSize = strlen($data);
+        $chunkBeginning = $byteSize . "\r\n";
+
+        return $chunkBeginning . $data . "\r\n";
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \React\Stream\ReadableStreamInterface::isReadable()
+     */
+
+    public function isReadable()
+    {
+        return !$this->closed && $this->input->isReadable();
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \React\Stream\ReadableStreamInterface::pause()
+     */
+    public function pause()
+    {
+        $this->input->pause();
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \React\Stream\ReadableStreamInterface::resume()
+     */
+    public function resume()
+    {
+        $this->input->resume();
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \React\Stream\ReadableStreamInterface::pipe()
+     */
+    public function pipe(WritableStreamInterface $dest, array $options = array())
+    {
+        Util::pipe($this, $dest, $options);
+
+        return $dest;
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \React\Stream\ReadableStreamInterface::close()
+     */
+    public function close()
+    {
+        if ($this->closing) {
+            return;
+        }
+
+        $this->closing = false;
+
+        $this->readable = false;
+
+        $this->emit('end', array($this));
+        $this->emit('close', array($this));
+        $this->removeAllListeners();
+    }
+}

--- a/src/ChunkedEncoderStream.php
+++ b/src/ChunkedEncoderStream.php
@@ -30,6 +30,10 @@ class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterfa
      */
     public function handleData($data)
     {
+        if ($data == '') {
+            return;
+        }
+
         $completeChunk = $this->createChunk($data);
 
         $this->emit('data', array($completeChunk));
@@ -68,6 +72,7 @@ class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterfa
     private function createChunk($data)
     {
         $byteSize = strlen($data);
+        $byteSize = dechex($byteSize);
         $chunkBeginning = $byteSize . "\r\n";
 
         return $chunkBeginning . $data . "\r\n";

--- a/src/ChunkedEncoderStream.php
+++ b/src/ChunkedEncoderStream.php
@@ -10,7 +10,6 @@ class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterfa
 {
     private $input;
     private $closed;
-    private $closing = false;
 
     public function __construct(ReadableStreamInterface $input)
     {
@@ -27,7 +26,10 @@ class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterfa
      */
     public function handleData($data)
     {
-        $completeChunk = $this->createChunk($data);
+        if (is_string($data)) {
+            $completeChunk = $this->createChunk($data);
+        }
+
         $this->emit('data', array($completeChunk));
     }
 
@@ -45,7 +47,7 @@ class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterfa
      */
     public function handleEnd($data = null)
     {
-        if ($data != null) {
+        if ($data != null && is_string($data)) {
             $completeChunk = $this->createChunk($data);
             $this->emit('data', array($completeChunk));
         }
@@ -126,11 +128,11 @@ class ChunkedEncoderStream extends EventEmitter implements ReadableStreamInterfa
      */
     public function close()
     {
-        if ($this->closing) {
+        if ($this->closed) {
             return;
         }
 
-        $this->closing = false;
+        $this->closed = true;
 
         $this->readable = false;
 

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -1,0 +1,254 @@
+<?php
+namespace Legionth\React\Http;
+
+use Psr\Http\Message\StreamInterface;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+use Evenement\EventEmitter;
+use React\Stream\Util;
+
+class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableStreamInterface
+{
+    private $input;
+    private $closed;
+    private $closing = false;
+
+    public function __construct(ReadableStreamInterface $input)
+    {
+        $this->input = $input;
+
+        $this->input->on('data', array($this, 'handleData'));
+        $this->input->on('end', array($this, 'handleEnd'));
+        $this->input->on('error', array($this, 'handleError'));
+        $this->input->on('close', array($this, 'close'));
+    }
+
+    public function handleData($data)
+    {
+        $this->emit('data', array($data));
+    }
+
+    public function handleError(\Exception $e)
+    {
+        $this->emit('error', array($e));
+        $this->close();
+    }
+
+    public function handleEnd()
+    {
+        if (!$this->closed) {
+            $this->emit('end');
+            $this->close();
+        }
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::__toString()
+     */
+    public function __toString()
+    {
+        return '';
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::detach()
+     */
+    public function detach()
+    {}
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::getSize()
+     */
+    public function getSize()
+    {
+        return 0;
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::tell()
+     */
+    public function tell()
+    {
+        return;
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::eof()
+     */
+    public function eof()
+    {
+        return;
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::isSeekable()
+     */
+    public function isSeekable()
+    {
+        return false;
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::seek()
+     */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        return false;
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::rewind()
+     */
+    public function rewind()
+    {
+        return;
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::isWritable()
+     */
+    public function isWritable()
+    {
+        return false;
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::write()
+     */
+    public function write($string)
+    {
+        return;
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::read()
+     */
+    public function read($length)
+    {
+        // TODO: Auto-generated method stub
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::getContents()
+     */
+    public function getContents()
+    {
+        echo "test";
+        return '';
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \Psr\Http\Message\StreamInterface::getMetadata()
+     */
+    public function getMetadata($key = null)
+    {
+        // TODO: Auto-generated method stub
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \React\Stream\ReadableStreamInterface::isReadable()
+     */
+
+    public function isReadable()
+    {
+        return !$this->closed && $this->input->isReadable();
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \React\Stream\ReadableStreamInterface::pause()
+     */
+    public function pause()
+    {
+        $this->input->pause();
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \React\Stream\ReadableStreamInterface::resume()
+     */
+    public function resume()
+    {
+        $this->input->resume();
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \React\Stream\ReadableStreamInterface::pipe()
+     */
+    public function pipe(WritableStreamInterface $dest, array $options = [])
+    {
+        Util::pipe($this, $dest, $options);
+
+        return $dest;
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     *
+     * @see \React\Stream\ReadableStreamInterface::close()
+     */
+    public function close()
+    {
+        if ($this->closing) {
+            return;
+        }
+
+        $this->closing = false;
+
+        $this->readable = false;
+
+        $this->emit('end', array($this));
+        $this->emit('close', array($this));
+        $this->removeAllListeners();
+    }
+}

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -10,8 +10,7 @@ use React\Stream\Util;
 class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableStreamInterface
 {
     private $input;
-    private $closed;
-    private $closing = false;
+    private $closed = false;
 
     public function __construct(ReadableStreamInterface $input)
     {
@@ -247,11 +246,11 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
      */
     public function close()
     {
-        if ($this->closing) {
+        if ($this->closed) {
             return;
         }
 
-        $this->closing = false;
+        $this->closed = true;
 
         $this->readable = false;
 

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -10,6 +10,9 @@ use React\Stream\Util;
 /**
  * Uses a StreamInterface from PSR-7 and a ReadableStreamInterface from ReactPHP
  * to use PSR-7 objects and use ReactPHP streams
+ * This is class is used in `HttpServer` to stream the body of a response
+ * to the client. Because of this you can stream big amount of data without
+ * necessity of buffering this data. The data will be send directly to the client.
  */
 class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableStreamInterface
 {
@@ -17,6 +20,17 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
     private $closed = false;
     private $encoder;
 
+    /**
+     * @param ReadableStreamInterface $input - The data from this stream will be forwarded
+     *                                         to the $encoder. The $encoder can be commited
+     *                                         via the second parameter of this constructor
+     * @param ReadableStreamInterface $encoder - This is a optional parameter which
+     *                                           can be an encoding stream. This encoder
+     *                                           will encode the data of $input. The
+     *                                           default is a `ChunkedEncoderStream`
+     *                                           which will encode the incoming data of
+     *                                           $input as HTTP chunks.
+     */
     public function __construct(ReadableStreamInterface $input, ReadableStreamInterface $encoder = null)
     {
         $this->input = $input;

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -33,41 +33,6 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
         $this->input->on('close', array($this, 'close'));
     }
 
-    public function getEncoder()
-    {
-        return $this->encoder;
-    }
-
-    /**
-     * Emits the data
-     * @param string $data - data to be emitted
-     */
-    public function handleData($data)
-    {
-        $this->emit('data', array($data));
-    }
-
-    /**
-     * Handles occuring exceptions on the stream
-     * @param \Exception $e
-     */
-    public function handleError(\Exception $e)
-    {
-        $this->emit('error', array($e));
-        $this->close();
-    }
-
-    /**
-     * Handles the end of the stream
-     */
-    public function handleEnd()
-    {
-        if (!$this->closed) {
-            $this->emit('end');
-            $this->close();
-        }
-    }
-
     public function isReadable()
     {
         return !$this->closed && $this->input->isReadable();
@@ -77,6 +42,7 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
     {
         $this->input->pause();
     }
+
 
     public function resume()
     {
@@ -181,5 +147,27 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
     public function getMetadata($key = null)
     {
         return null;
+    }
+
+    /** @internal */
+    public function handleData($data)
+    {
+        $this->emit('data', array($data));
+    }
+
+    /** @internal */
+    public function handleError(\Exception $e)
+    {
+        $this->emit('error', array($e));
+        $this->close();
+    }
+
+    /** @internal */
+    public function handleEnd()
+    {
+        if (!$this->closed) {
+            $this->emit('end');
+            $this->close();
+        }
     }
 }

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -223,7 +223,7 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
      *
      * @see \React\Stream\ReadableStreamInterface::pipe()
      */
-    public function pipe(WritableStreamInterface $dest, array $options = [])
+    public function pipe(WritableStreamInterface $dest, array $options = array())
     {
         Util::pipe($this, $dest, $options);
 

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -68,71 +68,6 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
         }
     }
 
-    public function __toString()
-    {
-        return '';
-    }
-
-    public function detach()
-    {
-        throw new \BadMethodCallException();
-    }
-
-    public function getSize()
-    {
-        return 0;
-    }
-
-    public function tell()
-    {
-        throw new \BadMethodCallException();
-    }
-
-    public function eof()
-    {
-        throw new \BadMethodCallException();
-    }
-
-    public function isSeekable()
-    {
-        return false;
-    }
-
-    public function seek($offset, $whence = SEEK_SET)
-    {
-        return false;
-    }
-
-    public function rewind()
-    {
-        return;
-    }
-
-    public function isWritable()
-    {
-        return false;
-    }
-
-    public function write($string)
-    {
-        throw new \BadMethodCallException();
-    }
-
-    public function read($length)
-    {
-        throw new \BadMethodCallException();
-    }
-
-    public function getContents()
-    {
-        return '';
-    }
-
-    public function getMetadata($key = null)
-    {
-        return array();
-    }
-
     public function isReadable()
     {
         return !$this->closed && $this->input->isReadable();
@@ -168,5 +103,83 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
         $this->emit('end', array($this));
         $this->emit('close', array($this));
         $this->removeAllListeners();
+    }
+
+    /** @ignore */
+    public function __toString()
+    {
+        return '';
+    }
+
+    /** @ignore */
+    public function detach()
+    {
+        return null;
+    }
+
+    /** @ignore */
+    public function getSize()
+    {
+        return null;
+    }
+
+    /** @ignore */
+    public function tell()
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function eof()
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function isSeekable()
+    {
+        return false;
+    }
+
+    /** @ignore */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function rewind()
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function isWritable()
+    {
+        return false;
+    }
+
+    /** @ignore */
+    public function write($string)
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function read($length)
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /** @ignore */
+    public function getContents()
+    {
+        return '';
+    }
+
+    /** @ignore */
+    public function getMetadata($key = null)
+    {
+        return null;
     }
 }

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -23,17 +23,26 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
         $this->input->on('close', array($this, 'close'));
     }
 
+    /**
+     * @internal
+     */
     public function handleData($data)
     {
         $this->emit('data', array($data));
     }
 
+    /**
+     * @internal
+     */
     public function handleError(\Exception $e)
     {
         $this->emit('error', array($e));
         $this->close();
     }
 
+    /**
+     * @internal
+     */
     public function handleEnd()
     {
         if (!$this->closed) {

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -15,15 +15,26 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
 {
     private $input;
     private $closed = false;
+    private $encoder;
 
-    public function __construct(ReadableStreamInterface $input)
+    public function __construct(ReadableStreamInterface $input, ReadableStreamInterface $encoder = null)
     {
         $this->input = $input;
 
-        $this->input->on('data', array($this, 'handleData'));
-        $this->input->on('end', array($this, 'handleEnd'));
-        $this->input->on('error', array($this, 'handleError'));
-        $this->input->on('close', array($this, 'close'));
+        if ($encoder === null) {
+            $encoder = new ChunkedEncoderStream($this->input);
+        }
+        $this->encoder = $encoder;
+
+        $this->encoder->on('data', array($this, 'handleData'));
+        $this->encoder->on('end', array($this, 'handleEnd'));
+        $this->encoder->on('error', array($this, 'handleError'));
+        $this->encoder->on('close', array($this, 'close'));
+    }
+
+    public function getEncoder()
+    {
+        return $this->encoder;
     }
 
     /**

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -7,6 +7,10 @@ use React\Stream\WritableStreamInterface;
 use Evenement\EventEmitter;
 use React\Stream\Util;
 
+/**
+ * Uses a StreamInterface from PSR-7 and a ReadableStreamInterface from ReactPHP
+ * to use PSR-7 objects and use ReactPHP streams
+ */
 class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableStreamInterface
 {
     private $input;
@@ -23,7 +27,8 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
     }
 
     /**
-     * @internal
+     * Emits the data
+     * @param string $data - data to be emitted
      */
     public function handleData($data)
     {
@@ -31,7 +36,8 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
     }
 
     /**
-     * @internal
+     * Handles occuring exceptions on the stream
+     * @param \Exception $e
      */
     public function handleError(\Exception $e)
     {
@@ -40,7 +46,7 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
     }
 
     /**
-     * @internal
+     * Handles the end of the stream
      */
     public function handleEnd()
     {
@@ -50,187 +56,84 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
         }
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::__toString()
-     */
     public function __toString()
     {
         return '';
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::detach()
-     */
     public function detach()
     {}
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::getSize()
-     */
     public function getSize()
     {
         return 0;
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::tell()
-     */
     public function tell()
     {
         return;
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::eof()
-     */
     public function eof()
     {
         return;
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::isSeekable()
-     */
     public function isSeekable()
     {
         return false;
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::seek()
-     */
     public function seek($offset, $whence = SEEK_SET)
     {
         return false;
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::rewind()
-     */
     public function rewind()
     {
         return;
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::isWritable()
-     */
     public function isWritable()
     {
         return false;
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::write()
-     */
     public function write($string)
     {
         return;
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::read()
-     */
     public function read($length)
     {
         // TODO: Auto-generated method stub
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::getContents()
-     */
     public function getContents()
     {
         return '';
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \Psr\Http\Message\StreamInterface::getMetadata()
-     */
     public function getMetadata($key = null)
     {
         // TODO: Auto-generated method stub
     }
-
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \React\Stream\ReadableStreamInterface::isReadable()
-     */
 
     public function isReadable()
     {
         return !$this->closed && $this->input->isReadable();
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \React\Stream\ReadableStreamInterface::pause()
-     */
     public function pause()
     {
         $this->input->pause();
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \React\Stream\ReadableStreamInterface::resume()
-     */
     public function resume()
     {
         $this->input->resume();
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \React\Stream\ReadableStreamInterface::pipe()
-     */
     public function pipe(WritableStreamInterface $dest, array $options = array())
     {
         Util::pipe($this, $dest, $options);
@@ -238,12 +141,6 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
         return $dest;
     }
 
-    /**
-     *
-     * {@inheritdoc}
-     *
-     * @see \React\Stream\ReadableStreamInterface::close()
-     */
     public function close()
     {
         if ($this->closed) {

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -21,29 +21,16 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
     private $encoder;
 
     /**
-     * @param ReadableStreamInterface $input - The data from this stream will be forwarded
-     *                                         to the $encoder. The $encoder can be commited
-     *                                         via the second parameter of this constructor
-     * @param ReadableStreamInterface $encoder - This is a optional parameter which
-     *                                           can be an encoding stream. This encoder
-     *                                           will encode the data of $input. The
-     *                                           default is a `ChunkedEncoderStream`
-     *                                           which will encode the incoming data of
-     *                                           $input as HTTP chunks.
+     * @param ReadableStreamInterface $input - Stream data from $stream as a body of a PSR-7 object
      */
-    public function __construct(ReadableStreamInterface $input, ReadableStreamInterface $encoder = null)
+    public function __construct(ReadableStreamInterface $input)
     {
         $this->input = $input;
 
-        if ($encoder === null) {
-            $encoder = new ChunkedEncoderStream($this->input);
-        }
-        $this->encoder = $encoder;
-
-        $this->encoder->on('data', array($this, 'handleData'));
-        $this->encoder->on('end', array($this, 'handleEnd'));
-        $this->encoder->on('error', array($this, 'handleError'));
-        $this->encoder->on('close', array($this, 'close'));
+        $this->input->on('data', array($this, 'handleData'));
+        $this->input->on('end', array($this, 'handleEnd'));
+        $this->input->on('error', array($this, 'handleError'));
+        $this->input->on('close', array($this, 'close'));
     }
 
     public function getEncoder()
@@ -87,7 +74,9 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
     }
 
     public function detach()
-    {}
+    {
+        throw new \BadMethodCallException();
+    }
 
     public function getSize()
     {

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -71,12 +71,12 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
 
     public function tell()
     {
-        return;
+        throw new \BadMethodCallException();
     }
 
     public function eof()
     {
-        return;
+        throw new \BadMethodCallException();
     }
 
     public function isSeekable()
@@ -101,12 +101,12 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
 
     public function write($string)
     {
-        return;
+        throw new \BadMethodCallException();
     }
 
     public function read($length)
     {
-        // TODO: Auto-generated method stub
+        throw new \BadMethodCallException();
     }
 
     public function getContents()
@@ -116,7 +116,7 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
 
     public function getMetadata($key = null)
     {
-        // TODO: Auto-generated method stub
+        return array();
     }
 
     public function isReadable()

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -169,7 +169,6 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
      */
     public function getContents()
     {
-        echo "test";
         return '';
     }
 

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -193,13 +193,8 @@ class HttpServer extends EventEmitter
                 if ($response instanceof Response) {
                     $body = $response->getBody();
                     if ($body instanceof ReadableStreamInterface) {
-                        $headerResponse = new Response(
-                            $response->getStatusCode(),
-                            $response->getHeaders(),
-                            null,
-                            $response->getProtocolVersion(),
-                            $response->getReasonPhrase()
-                        );
+                        $emptyBody =RingCentral\Psr7\stream_for('');
+                        $headerResponse = $response->withBody($emptyBody);
 
                         $connection->write(RingCentral\Psr7\str($headerResponse));
                         $body->pipe($connection);

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -195,14 +195,13 @@ class HttpServer extends EventEmitter
                     $body = $response->getBody();
                     if ($body instanceof ReadableStreamInterface) {
                         // reset Transfer-Encoding header and set always chunked encoding
-                        $response = $response->withoutHeader('Transfer-Encoding');
                         $response = $response->withHeader('Transfer-Encoding', 'chunked');
                         // Send the header first without the body,
                         // the body will be streamed
                         $emptyBody = RingCentral\Psr7\stream_for('');
-                        $headerResponse = $response->withBody($emptyBody);
+                        $response = $response->withBody($emptyBody);
 
-                        $connection->write(RingCentral\Psr7\str($headerResponse));
+                        $connection->write(RingCentral\Psr7\str($response));
                         $chunkedEncoder = new ChunkedEncoderStream($body);
                         $chunkedEncoder->pipe($connection);
 

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -193,7 +193,9 @@ class HttpServer extends EventEmitter
                 if ($response instanceof Response) {
                     $body = $response->getBody();
                     if ($body instanceof ReadableStreamInterface) {
-                        $emptyBody =RingCentral\Psr7\stream_for('');
+                        // Send the header first without the body, 
+                        // the body will be streamed
+                        $emptyBody = RingCentral\Psr7\stream_for('');
                         $headerResponse = $response->withBody($emptyBody);
 
                         $connection->write(RingCentral\Psr7\str($headerResponse));

--- a/tests/ChunkedEncoderStreamTest.php
+++ b/tests/ChunkedEncoderStreamTest.php
@@ -14,11 +14,22 @@ class ChunkedEncoderStreamTest extends TestCase
         $this->chunkedStream = new ChunkedEncoderStream($this->input);
     }
 
-
     public function testChunked()
     {
         $this->chunkedStream->on('data', $this->expectCallableOnce(array("5\r\nhello\r\n")));
         $this->input->emit('data', array('hello'));
+    }
+
+    public function testEmptyString()
+    {
+        $this->chunkedStream->on('data', $this->expectCallableNever());
+        $this->input->emit('data', array(''));
+    }
+
+    public function testBiggerStringToCheckHexValue()
+    {
+        $this->chunkedStream->on('data', $this->expectCallableOnce(array("1a\r\nabcdefghijklmnopqrstuvwxyz\r\n")));
+        $this->input->emit('data', array('abcdefghijklmnopqrstuvwxyz'));
     }
 
     public function testHandleClose()

--- a/tests/ChunkedEncoderStreamTest.php
+++ b/tests/ChunkedEncoderStreamTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use React\Stream\ReadableStream;
+use Legionth\React\Http\ChunkedEncoderStream;
+
+class ChunkedEncoderStreamTest extends TestCase
+{
+    private $input;
+    private $chunkedStream;
+
+    public function setUp()
+    {
+        $this->input = new ReadableStream();
+        $this->chunkedStream = new ChunkedEncoderStream($this->input);
+    }
+
+
+    public function testChunked()
+    {
+        $this->chunkedStream->on('data', $this->expectCallableOnce(array("5\r\nhello\r\n")));
+        $this->input->emit('data', array('hello'));
+    }
+
+    public function testHandleClose()
+    {
+        $this->chunkedStream->on('close', $this->expectCallableOnce());
+
+        $this->input->close();
+
+        $this->assertFalse($this->chunkedStream->isReadable());
+    }
+
+    public function testHandleError()
+    {
+        $this->chunkedStream->on('error', $this->expectCallableOnce());
+        $this->chunkedStream->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('error', array(new \RuntimeException()));
+
+        $this->assertFalse($this->chunkedStream->isReadable());
+    }
+
+    public function testPauseStream()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $input->expects($this->once())->method('pause');
+
+        $parser = new ChunkedEncoderStream($input);
+        $parser->pause();
+    }
+
+    public function testResumeStream()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $input->expects($this->once())->method('pause');
+
+        $parser = new ChunkedEncoderStream($input);
+        $parser->pause();
+        $parser->resume();
+    }
+
+    public function testPipeStream()
+    {
+        $dest = $this->getMock('React\Stream\WritableStreamInterface');
+
+        $ret = $this->chunkedStream->pipe($dest);
+
+        $this->assertSame($dest, $ret);
+    }
+
+    private function expectCallableConsecutive($numberOfCalls, array $with)
+    {
+        $mock = $this->createCallableMock();
+
+        for ($i = 0; $i < $numberOfCalls; $i++) {
+            $mock
+            ->expects($this->at($i))
+            ->method('__invoke')
+            ->with($this->equalTo($with[$i]));
+        }
+
+        return $mock;
+    }
+}

--- a/tests/HttpBodyStreamTest.php
+++ b/tests/HttpBodyStreamTest.php
@@ -77,12 +77,12 @@ class HttpBodyStreamTest extends TestCase
 
     public function testDetach()
     {
-        $this->bodyStream->detach();
+        $this->assertEquals(null, $this->bodyStream->detach());
     }
 
     public function testGetSize()
     {
-        $this->assertEquals(0, $this->bodyStream->getSize());
+        $this->assertEquals(null, $this->bodyStream->getSize());
     }
 
     /**
@@ -129,7 +129,7 @@ class HttpBodyStreamTest extends TestCase
 
     public function testGetMetaData()
     {
-        $this->assertEquals(array(), $this->bodyStream->getMetadata());
+        $this->assertEquals(null, $this->bodyStream->getMetadata());
     }
 
     public function testIsReadable()
@@ -147,11 +147,17 @@ class HttpBodyStreamTest extends TestCase
         $this->bodyStream->resume();
     }
 
+    /**
+     * @expectedException BadMethodCallException
+     */
     public function testSeek()
     {
-        $this->assertFalse($this->bodyStream->seek(''));
+        $this->bodyStream->seek('');
     }
 
+    /**
+     * @expectedException BadMethodCallException
+     */
     public function testRewind()
     {
         $this->bodyStream->rewind();

--- a/tests/HttpBodyStreamTest.php
+++ b/tests/HttpBodyStreamTest.php
@@ -1,0 +1,165 @@
+<?php
+use Legionth\React\Http\HttpBodyStream;
+use React\Stream\ReadableStream;
+use React\Stream\WritableStream;
+
+class HttpBodyStreamTest extends TestCase
+{
+    private $input;
+    private $bodyStream;
+
+    public function setUp()
+    {
+        $this->input = new ReadableStream();
+        $this->bodyStream = new HttpBodyStream($this->input);
+    }
+
+    public function testDataEmit()
+    {
+        $this->bodyStream->on('data', $this->expectCallableOnce(array("hello")));
+        $this->input->emit('data', array("hello"));
+    }
+
+    public function testPauseStream()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $input->expects($this->once())
+            ->method('pause');
+
+        $bodyStream = new HttpBodyStream($input);
+        $bodyStream->pause();
+    }
+
+    public function testResumeStream()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $input->expects($this->once())
+            ->method('pause');
+
+        $bodyStream = new HttpBodyStream($input);
+        $bodyStream->pause();
+        $bodyStream->resume();
+    }
+
+    public function testPipeStream()
+    {
+        $dest = $this->getMock('React\Stream\WritableStreamInterface');
+
+        $ret = $this->bodyStream->pipe($dest);
+
+        $this->assertSame($dest, $ret);
+    }
+
+    public function testHandleClose()
+    {
+        $this->bodyStream->on('close', $this->expectCallableOnce());
+
+        $this->input->close();
+        $this->input->emit('end', array());
+
+        $this->assertFalse($this->bodyStream->isReadable());
+    }
+
+    public function testHandleError()
+    {
+        $this->bodyStream->on('error', $this->expectCallableOnce());
+        $this->bodyStream->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('error', array(new \RuntimeException()));
+
+        $this->assertFalse($this->bodyStream->isReadable());
+    }
+
+    public function testToString()
+    {
+        $this->assertEquals('', $this->bodyStream->__toString());
+    }
+
+    public function testDetach()
+    {
+        $this->bodyStream->detach();
+    }
+
+    public function testGetSize()
+    {
+        $this->assertEquals(0, $this->bodyStream->getSize());
+    }
+
+    public function testTell()
+    {
+        $this->bodyStream->tell();
+    }
+
+    public function testEof()
+    {
+        $this->bodyStream->eof();
+    }
+
+    public function testIsSeekable()
+    {
+        $this->assertFalse($this->bodyStream->isSeekable());
+    }
+
+    public function testWrite()
+    {
+        $this->bodyStream->write('');
+    }
+
+    public function testRead()
+    {
+        $this->bodyStream->read('');
+    }
+
+    public function testGetContents()
+    {
+        $this->assertEquals('', $this->bodyStream->getContents());
+    }
+
+    public function testGetMetaData()
+    {
+        $this->assertEquals('', $this->bodyStream->getMetadata());
+    }
+
+    public function testIsReadable()
+    {
+        $this->assertTrue($this->bodyStream->isReadable());
+    }
+
+    public function testPause()
+    {
+        $this->bodyStream->pause();
+    }
+
+    public function testResume()
+    {
+        $this->bodyStream->resume();
+    }
+
+    public function testSeek()
+    {
+        $this->assertFalse($this->bodyStream->seek(''));
+    }
+
+    public function testRewind()
+    {
+        $this->bodyStream->rewind();
+    }
+
+    public function testIsWriteable()
+    {
+        $this->assertFalse($this->bodyStream->isWritable());
+    }
+
+    private function expectCallableConsecutive($numberOfCalls, array $with)
+    {
+        $mock = $this->createCallableMock();
+
+        for ($i = 0; $i < $numberOfCalls; $i ++) {
+            $mock->expects($this->at($i))
+                ->method('__invoke')
+                ->with($this->equalTo($with[$i]));
+        }
+
+        return $mock;
+    }
+}

--- a/tests/HttpBodyStreamTest.php
+++ b/tests/HttpBodyStreamTest.php
@@ -85,11 +85,17 @@ class HttpBodyStreamTest extends TestCase
         $this->assertEquals(0, $this->bodyStream->getSize());
     }
 
+    /**
+     * @expectedException BadMethodCallException
+     */
     public function testTell()
     {
         $this->bodyStream->tell();
     }
 
+    /**
+     * @expectedException BadMethodCallException
+     */
     public function testEof()
     {
         $this->bodyStream->eof();
@@ -100,11 +106,17 @@ class HttpBodyStreamTest extends TestCase
         $this->assertFalse($this->bodyStream->isSeekable());
     }
 
+    /**
+     * @expectedException BadMethodCallException
+     */
     public function testWrite()
     {
         $this->bodyStream->write('');
     }
 
+    /**
+     * @expectedException BadMethodCallException
+     */
     public function testRead()
     {
         $this->bodyStream->read('');
@@ -117,7 +129,7 @@ class HttpBodyStreamTest extends TestCase
 
     public function testGetMetaData()
     {
-        $this->assertEquals('', $this->bodyStream->getMetadata());
+        $this->assertEquals(array(), $this->bodyStream->getMetadata());
     }
 
     public function testIsReadable()

--- a/tests/HttpServerTest.php
+++ b/tests/HttpServerTest.php
@@ -9,7 +9,6 @@ use React\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
 use Legionth\React\Http\HttpBodyStream;
 use React\Stream\ReadableStream;
-use Legionth\React\Http\ChunkedEncoderStream;
 
 class HttpServerTest extends TestCase
 {
@@ -350,32 +349,7 @@ class HttpServerTest extends TestCase
 
         $socket->emit('connection', array($this->connection));
 
-        $this->connection->expects($this->once())->method('write')->with($this->equalTo("HTTP/1.1 200 OK\r\nTransfer-Encoding: another, chunked\r\n\r\n"));
-
-        $this->connection->emit('data', array($request));
-    }
-
-    public function testAnotherEncoderForStreaming()
-    {
-        $callback = function(RequestInterface $request) {
-            $stream = new ReadableStream();
-
-            $body = new HttpBodyStream($stream, new ReadableStream());
-
-            return new Response(
-                200,
-                array(),
-                $body);
-        };
-
-        $request = "GET / HTTP/1.1\r\nHost: me.you\r\n\r\n";
-
-        $socket = new Socket($this->loop);
-        $server = new HttpServer($socket, $callback);
-
-        $socket->emit('connection', array($this->connection));
-
-        $this->connection->expects($this->once())->method('write')->with($this->equalTo("HTTP/1.1 200 OK\r\n\r\n"));
+        $this->connection->expects($this->once())->method('write')->with($this->equalTo("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"));
 
         $this->connection->emit('data', array($request));
     }


### PR DESCRIPTION
Added a possibility to stream the entire body via ReactPHP [stream](https://github.com/reactphp/stream) but still using the needed `StreamInterface` defined by the PSR-7 specification for response objects.

The body which will generated by the user of the server, can use an ReactPHP stream to stream the entire body to the client. Check out the example in the `examples` folder.

Most of the functions from the `StreamInterface` aren't needed for further operations of the `HttpServer`, that's why there so many dummy return values for these.